### PR TITLE
Fix scripts, add test framework, add admin mode

### DIFF
--- a/external-scripts.json
+++ b/external-scripts.json
@@ -8,5 +8,6 @@
   "hubot-maps",
   "hubot-redis-brain",
   "hubot-rules",
-  "hubot-shipit"
+  "hubot-shipit",
+  "hubot-auth"
 ]

--- a/package.json
+++ b/package.json
@@ -4,8 +4,12 @@
   "private": true,
   "author": "Andrew Seward <abseward@googlemail.com>",
   "description": "Hackbot is here to help you hack",
+  "scripts": {
+    "test": "mocha --compilers coffee:coffee-script/register --reporter spec"
+  },
   "dependencies": {
     "hubot": "^2.18.0",
+    "hubot-auth": "^1.2.0",
     "hubot-diagnostics": "0.0.1",
     "hubot-google-images": "^0.2.6",
     "hubot-google-translate": "^0.2.0",
@@ -21,5 +25,13 @@
   },
   "engines": {
     "node": "0.10.x"
+  },
+  "devDependencies": {
+    "chai": "^3.5.0",
+    "coffee-script": "^1.10.0",
+    "hubot-test-helper": "^1.4.4",
+    "mocha": "^2.4.5",
+    "sinon": "^1.17.3",
+    "sinon-chai": "^2.8.0"
   }
 }

--- a/scripts/hack24api.coffee
+++ b/scripts/hack24api.coffee
@@ -14,5 +14,3 @@ module.exports = (robot) ->
     
   robot.respond /my id/i, (response) ->
     response.reply "Your id is #{response.message.user.id}"
-
-  robot

--- a/scripts/hack24api.coffee
+++ b/scripts/hack24api.coffee
@@ -11,3 +11,8 @@ module.exports = (robot) ->
 
   robot.respond /what are your prime directives\??/i, (response) ->
     response.reply "1. Serve the public trust\n2. Protect the innocent hackers\n3. Uphold the Code of Conduct\n4. [Classified]"
+    
+  robot.respond /my id/i, (response) ->
+    response.reply "Your id is #{response.message.user.id}"
+
+  robot

--- a/scripts/hack24api.coffee
+++ b/scripts/hack24api.coffee
@@ -2,7 +2,7 @@ module.exports = (robot) ->
 
   robot.respond /can you see the api\??/i, (response) ->
     response.reply "I'll have a quick look for you Sir..."
-    robot.http("http://api.hack24.co.uk/teams")
+    robot.http("#{process.env.HACK24API_URL}/api")
       .get() (err, res, body) ->
         if res.statusCode isnt 200
           response.reply "I'm sorry Sir, there appears to be a problem; something about \"#{res.statusCode}\""

--- a/scripts/hack24api.coffee
+++ b/scripts/hack24api.coffee
@@ -1,10 +1,13 @@
 module.exports = (robot) ->
-  robot.respond /Can you see the API?/i, (response) ->
+
+  robot.respond /can you see the api\??/i, (response) ->
+    response.reply "I'll have a quick look for you Sir..."
     robot.http("http://api.hack24.co.uk/teams")
       .get() (err, res, body) ->
         if res.statusCode isnt 200
-          response.reply "I'm sorry Sir, I cannot see her."
+          response.reply "I'm sorry Sir, there appears to be a problem; something about \"#{res.statusCode}\""
           return
         response.reply "I see her!"
-  robot.respond /.*[your prime directives?]$/i, (response) ->
+
+  robot.respond /what are your prime directives\??/i, (response) ->
     response.reply "1. Serve the public trust\n2. Protect the innocent hackers\n3. Uphold the Code of Conduct\n4. [Classified]"

--- a/test/hack24api.coffee
+++ b/test/hack24api.coffee
@@ -1,0 +1,37 @@
+Helper = require('hubot-test-helper')
+chai = require 'chai'
+
+expect = chai.expect
+
+helper = new Helper('../scripts/hack24api.coffee')
+
+describe 'hack24api script', ->
+  beforeEach ->
+    @room = helper.createRoom()
+    @robot =
+      respond: sinon.spy()
+      http: sinon.spy()
+
+  afterEach ->
+    @room.destroy()
+
+#   it 'can see the hack24 api', ->
+#     @room.user.say('alice', 'can you see the api?').then =>
+#       expect(@room.messages).to.eql [
+#         ['alice', 'did someone call for a badger?']
+#         ['hubot', 'Badgers? BADGERS? WE DON\'T NEED NO STINKIN BADGERS']
+#       ]
+# 
+#   it 'won\'t open the pod bay doors', ->
+#     @room.user.say('bob', '@hubot open the pod bay doors').then =>
+#       expect(@room.messages).to.eql [
+#         ['bob', '@hubot open the pod bay doors']
+#         ['hubot', '@bob I\'m afraid I can\'t let you do that.']
+#       ]
+# 
+#   it 'will open the dutch doors', ->
+#     @room.user.say('bob', '@hubot open the dutch doors').then =>
+#       expect(@room.messages).to.eql [
+#         ['bob', '@hubot open the dutch doors']
+#         ['hubot', '@bob Opening dutch doors']
+#       ]


### PR DESCRIPTION
1. Run tests with `npm test`. Currently, there are no tests to be run, see `test/hack24api.coffee`.
2. Fixed the regex so the bot isn't double matching commands.
3. Add `hack-auth` to help with managing delegated admins.
