### PR TITLE
Add hackbot authentication

### DIFF
--- a/lib/client.coffee
+++ b/lib/client.coffee
@@ -1,3 +1,5 @@
+getAuth = () -> "#{process.env.HACKBOT_USERNAME}:#{process.env.HACKBOT_PASSWORD}"
+
 class Client
 
   @createTeam: (robot, teamName, userId) ->
@@ -6,7 +8,7 @@ class Client
         name: teamName
         members: [ userId ]
         
-      robot.http("#{process.env.HACK24API_URL}/teams")
+      http = robot.http("#{process.env.HACK24API_URL}/teams", { auth: getAuth() })
         .header('Content-Type', 'application/json')
         .post(body) (err, res, body) ->
           if err? then return reject err
@@ -18,7 +20,7 @@ class Client
         userid: userId
         name: userName
           
-      robot.http("#{process.env.HACK24API_URL}/users")
+      http = robot.http("#{process.env.HACK24API_URL}/users", { auth: getAuth() })
         .header('Content-Type', 'application/json')
         .post(body) (err, res, body) ->
           if err? then return reject err

--- a/scripts/hack24api.coffee
+++ b/scripts/hack24api.coffee
@@ -8,7 +8,7 @@
 #   hubot can you see the api? - checks if the API is visible
 #   hubot what are your prime directives? - cites hubot's prime directives
 #   hubot my id - echos the ID hubot knows you as
-#   hunot create team <team name> - tries to create team with name <team name> and adds you to it
+#   hubot create team <team name> - tries to create team with name <team name> and adds you to it
 #
 # Author:
 #   codesleuth


### PR DESCRIPTION
Requires the following environment variables:
- `HACKBOT_USERNAME`
- `HACKBOT_PASSWORD`

These should be set to the same as the API. See TechNottingham/Hack24-API#7.
